### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 ## Black Thursday
 
-Find the [project spec here](https://github.com/turingschool/curriculum/blob/master/source/projects/black_thursday.markdown).
+Find the [project spec here](https://github.com/turingschool/backend-curriculum-site/blob/gh-pages/module1/projects/black_thursday/index.md).


### PR DESCRIPTION
Update README.md to point to https://github.com/turingschool/backend-curriculum-site/ instead of the old github.com/turingschool/curriculum/